### PR TITLE
Update Kotlin to 1.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ repositories {
 }
 
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "1.1.50"
+    id("org.jetbrains.kotlin.jvm") version "1.2.30"
 }
 
 dependencies {


### PR DESCRIPTION
Closes #7

This PR updates the version of Kotlin used to 1.2 (1.2.30 specifically).